### PR TITLE
Remove default font size

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -30,7 +30,6 @@ $tabButtonBgActive: #2354ac;
 }
 
 %ddm-tabs__panelBase {
-  font-size: 16px;
   border-bottom: 1px solid #e1e1e1;
   padding: 20px;
 }


### PR DESCRIPTION
We shouldn't specify the font size of the panel content. It should be up to the content to decide what size it should be.