### PR TITLE
Change Max Width for Collapsible

### DIFF
--- a/src/components/TabsResponsive.jsx
+++ b/src/components/TabsResponsive.jsx
@@ -19,7 +19,7 @@ var TabsResponsive = React.createClass({
 
   getDefaultProps: function() {
     return {
-      convertQuery: '(max-width: 768px)',
+      convertQuery: '(max-width: 767px)',
       collapsibleSpeed: 700
     }
   },


### PR DESCRIPTION
The collapsible is currently changing to a tab at 769px which is one pixel higher than all the standard 768 breakpoints used for Homes and Cars.